### PR TITLE
rrd::cache: Added restrict_writes parameter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -58,6 +58,7 @@ The `rrd::cache` class has the following parameters:
 * *jump_dir*: Default is '/var/lib/rrdcached/db/'
 * *always_flush*: Default is true
 * *enable_corefiles*: Default is false
+* *restrict_writes*: Default is false
 * *maxwait*: Default is '30'
 * *conf_file*: The path to the `rrdcached` configuration file. Default is set approprately for operating system family.
 * *service_name*: The name of the `rrdcached` service. Default is set approprately for operating system family.

--- a/manifests/cache.pp
+++ b/manifests/cache.pp
@@ -44,7 +44,8 @@ class rrd::cache (
   $enable_corefiles = $rrd::params::cache_enable_corefiles,
   $maxwait          = $rrd::params::cache_maxwait,
   $conf_file        = $rrd::params::cache_conf_file,
-  $service_name     = $rrd::params::cache_service
+  $service_name     = $rrd::params::cache_service,
+  $restrict_writes  = $rrd::params::restrict_writes,
 ) inherits rrd::params {
 
   package{$rrd::params::cache_package:
@@ -64,19 +65,19 @@ class rrd::cache (
   file{'rrdcached.conf':
     ensure  => file,
     path    => $conf_file,
-    mode    => 0644,
+    mode    => '0644',
     content => template('rrd/rrdcached.conf.erb'),
     notify  => Service['rrdcached'],
     require => Package[$rrd::params::cache_package],
   }
 
   service{'rrdcached':
-    name        => $service_name,
-    ensure      => $service,
-    enable      => $service_enable,
-    hasstatus   => true,
-    hasrestart  => true,
-    require     => Package[$rrd::params::cache_package],
+    ensure     => $service,
+    name       => $service_name,
+    enable     => $service_enable,
+    hasstatus  => true,
+    hasrestart => true,
+    require    => Package[$rrd::params::cache_package],
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,7 @@ class rrd::params {
   $cache_jump_dir         = '/var/lib/rrdcached/db/'
   $cache_always_flush     = true
   $cache_enable_corefiles = false
+  $cache_restrict_writes  = false
   $cache_maxwait          = '30'
 
   case $::osfamily {

--- a/templates/rrdcached.conf.erb
+++ b/templates/rrdcached.conf.erb
@@ -12,7 +12,7 @@ DISABLE=<%= @service_enable ? '0' : '1' %>
 # options to be passed to rrdcached
 # (do not specify -p <pidfile> - this is handled by the init script)
 # default: see /etc/init.d/rrdcached
-OPTS="-t <%= @write_threads %> -w <%= @timeout %> -z <%= @delay %> -j <%= @journal_dir %> <%- if @gid -%>-s <%= @gid %><% end %> -l <%= @listen %> <%= @always_flush ? '-F' : '' %> -b <%= @jump_dir %>"
+OPTS="-t <%= @write_threads %> -w <%= @timeout %> -z <%= @delay %> -j <%= @journal_dir %> <%- if @gid -%>-s <%= @gid %><% end %> -l <%= @listen %><%= @always_flush ? ' -F' : '' %> -b <%= @jump_dir %><%= @restrict_writes ? ' -B' : '' %>"
 
 # number of seconds to wait for rrdcached to shut down
 # (writing the data to disk may take some time;


### PR DESCRIPTION
Hi,
This PR just added the `$restrict_writes` parameter which is false by
default. It configures the `-B` option to rrdcached.

```
« Only permit writes into the base directory specified in -b (and any
sub-directories).  This does NOT detect symbolic links.  Paths
containing "../" will also be blocked. »
```
