### PR TITLE
spec: include_class matcher is deprecated

### DIFF
--- a/spec/classes/bindings/perl_spec.rb
+++ b/spec/classes/bindings/perl_spec.rb
@@ -7,7 +7,7 @@ describe 'rrd::bindings::perl', :type => :class do
         :osfamily               => 'Debian',
       }
     end
-    it {should include_class('rrd::params')}
+    it {should contain_class('rrd::params')}
     it {should contain_package('librrds-perl')}
     it {should contain_package('librrdp-perl')}
     it {should contain_package('librrdtool-oo-perl')}

--- a/spec/classes/bindings/php_spec.rb
+++ b/spec/classes/bindings/php_spec.rb
@@ -7,7 +7,7 @@ describe 'rrd::bindings::php', :type => :class do
         :osfamily               => 'Debian',
       }
     end
-    it {should include_class('rrd::params')}
+    it {should contain_class('rrd::params')}
     it {should contain_package('php5-rrd')}
   end
 end

--- a/spec/classes/bindings/python_spec.rb
+++ b/spec/classes/bindings/python_spec.rb
@@ -7,7 +7,7 @@ describe 'rrd::bindings::python', :type => :class do
         :osfamily               => 'Debian',
       }
     end
-    it {should include_class('rrd::params')}
+    it {should contain_class('rrd::params')}
     it {should contain_package('python-pyrrd')}
     it {should contain_package('python-rrdtool')}
   end

--- a/spec/classes/bindings/ruby_spec.rb
+++ b/spec/classes/bindings/ruby_spec.rb
@@ -7,7 +7,7 @@ describe 'rrd::bindings::ruby', :type => :class do
         :osfamily               => 'Debian',
       }
     end
-    it {should include_class('rrd::params')}
+    it {should contain_class('rrd::params')}
     it {should contain_package('librrd-ruby')}
   end
 end

--- a/spec/classes/bindings/tcl_spec.rb
+++ b/spec/classes/bindings/tcl_spec.rb
@@ -7,7 +7,7 @@ describe 'rrd::bindings::tcl', :type => :class do
         :osfamily               => 'Debian',
       }
     end
-    it {should include_class('rrd::params')}
+    it {should contain_class('rrd::params')}
     it {should contain_package('rrdtool-tcl')}
   end
 end

--- a/spec/classes/rrd/cache_spec.rb
+++ b/spec/classes/rrd/cache_spec.rb
@@ -7,7 +7,7 @@ describe 'rrd::cache', :type => :class do
         :osfamily               => 'Debian',
       }
     end
-    it {should include_class('rrd::params')}
+    it {should contain_class('rrd::params')}
     it {should contain_package('rrdcached')}
     it {should contain_service('rrdcached')}
     it {should contain_file('rrdcached.conf').with(

--- a/spec/classes/rrd/tool_spec.rb
+++ b/spec/classes/rrd/tool_spec.rb
@@ -7,7 +7,7 @@ describe 'rrd::tool', :type => :class do
         :osfamily               => 'Debian',
       }
     end
-    it {should include_class('rrd::params')}
+    it {should contain_class('rrd::params')}
     it {should contain_package('rrdtool')}
   end
 end

--- a/spec/classes/rrd_spec.rb
+++ b/spec/classes/rrd_spec.rb
@@ -7,7 +7,7 @@ describe 'rrd', :type => :class do
         :osfamily               => 'Debian',
       }
     end
-    it {should include_class('rrd::params')}
+    it {should contain_class('rrd::params')}
     it {should contain_package('librrd4')}
   end
 end


### PR DESCRIPTION
Replace all include_class rspec matcher by contain_class.
