### PR TITLE
added missing space between parameters

### DIFF
--- a/templates/rrdcached.conf.erb
+++ b/templates/rrdcached.conf.erb
@@ -12,7 +12,7 @@ DISABLE=<%= @service_enable ? '0' : '1' %>
 # options to be passed to rrdcached
 # (do not specify -p <pidfile> - this is handled by the init script)
 # default: see /etc/init.d/rrdcached
-OPTS="-t <%= @write_threads %> -w <%= @timeout %> -z <%= @delay %> -j <%= @journal_dir %> <%- if @gid -%>-s <%= @gid %><% end %> -l <%= @listen %><%= @always_flush ? ' -F' : '' %> -b <%= @jump_dir %><%= @restrict_writes ? ' -B' : '' %>"
+OPTS="-t <%= @write_threads %> -w <%= @timeout %> -z <%= @delay %> -j <%= @journal_dir %> <%- if @gid -%> -s <%= @gid %><% end %> -l <%= @listen %><%= @always_flush ? ' -F' : '' %> -b <%= @jump_dir %><%= @restrict_writes ? ' -B' : '' %>"
 
 # number of seconds to wait for rrdcached to shut down
 # (writing the data to disk may take some time;


### PR DESCRIPTION
I configured a custom gid in the puppet file and that lead to an invalid command line. Between the socket path and the -s parameter was no space. This change fixes it for me.

-OPTS="-t 4 -w 1800 -z 1800 -j /var/lib/rrdcached/journal/-s www-data -l unix:/var/run/rrdcached.sock -F -b /var/lib/rrdcached/db/"
+OPTS="-t 4 -w 1800 -z 1800 -j /var/lib/rrdcached/journal/ -s www-data -l unix:/var/run/rrdcached.sock -F -b /var/lib/rrdcached/db/"
